### PR TITLE
Updated to support large payloads in iOS8

### DIFF
--- a/ApnsPHP/Message.php
+++ b/ApnsPHP/Message.php
@@ -33,7 +33,7 @@
  */
 class ApnsPHP_Message
 {
-	const PAYLOAD_MAXIMUM_SIZE = 256; /**< @type integer The maximum size allowed for a notification payload. */
+	const PAYLOAD_MAXIMUM_SIZE = 2048; /**< @type integer The maximum size allowed for a notification payload. */
 	const APPLE_RESERVED_NAMESPACE = 'aps'; /**< @type string The Apple-reserved aps namespace. */
 
 	protected $_bAutoAdjustLongPayload = true; /**< @type boolean If the JSON payload is longer than maximum allowed size, shorts message text. */

--- a/ApnsPHP/Push.php
+++ b/ApnsPHP/Push.php
@@ -55,8 +55,8 @@ class ApnsPHP_Push extends ApnsPHP_Abstract
 	protected $_nSendRetryTimes = 3; /**< @type integer Send retry times. */
 
 	protected $_aServiceURLs = array(
-		'ssl://gateway.push.apple.com:2195', // Production environment
-		'ssl://gateway.sandbox.push.apple.com:2195' // Sandbox environment
+		'tls://gateway.push.apple.com:2195', // Production environment
+		'tls://gateway.sandbox.push.apple.com:2195' // Sandbox environment
 	); /**< @type array Service URLs environments. */
 
 	protected $_aMessageQueue = array(); /**< @type array Message queue. */


### PR DESCRIPTION
Removed 256 byte limit and replaced with 2048 bytes.